### PR TITLE
Add Simple Stock Feature

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,7 @@
 ### Unreleased
 ##### 2019-XX-XX
 
-- 
+- Added product stock feature
 
 ## 0.5 Series
 

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -59,10 +59,7 @@ class Product extends Model implements ProductContract
         return $this->isActive();
     }
 
-    /**
-     * @return bool
-     */
-    public function isOnStock()
+    public function isOnStock(): bool
     {
         return $this->stock > 0;
     }

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -59,6 +59,14 @@ class Product extends Model implements ProductContract
         return $this->isActive();
     }
 
+    /**
+     * @return bool
+     */
+    public function isOnStock()
+    {
+        return $this->stock > 0;
+    }
+
     public function title()
     {
         return isset($this->ext_title) ? $this->ext_title : $this->name;

--- a/src/resources/database/migrations/2017_10_07_133259_create_products_table.php
+++ b/src/resources/database/migrations/2017_10_07_133259_create_products_table.php
@@ -19,6 +19,7 @@ class CreateProductsTable extends Migration
             $table->string('slug')->nullable();
             $table->string('sku');
             $table->decimal('price', 15, 4)->nullable();
+            $table->decimal('stock', 15, 4)->default(0);
             $table->text('excerpt')->nullable();
             $table->text('description')->nullable();
             $table->enum('state', ProductStateProxy::values())->default(ProductStateProxy::defaultValue());

--- a/src/resources/database/migrations/2017_10_07_133259_create_products_table.php
+++ b/src/resources/database/migrations/2017_10_07_133259_create_products_table.php
@@ -19,7 +19,6 @@ class CreateProductsTable extends Migration
             $table->string('slug')->nullable();
             $table->string('sku');
             $table->decimal('price', 15, 4)->nullable();
-            $table->decimal('stock', 15, 4)->default(0);
             $table->text('excerpt')->nullable();
             $table->text('description')->nullable();
             $table->enum('state', ProductStateProxy::values())->default(ProductStateProxy::defaultValue());

--- a/src/resources/database/migrations/2019_04_08_000000_add_stock_field_to_products_table.php
+++ b/src/resources/database/migrations/2019_04_08_000000_add_stock_field_to_products_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddStockFieldToProductsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->decimal('stock', 15, 4)->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropColumn('stock');
+        });
+    }
+}

--- a/tests/BaseProductAttributesTest.php
+++ b/tests/BaseProductAttributesTest.php
@@ -55,6 +55,7 @@ class BaseProductAttributesTest extends TestCase
         $product = Product::create([
             'name'             => 'Maxi Baxi 2000',
             'sku'              => 'MXB-2000',
+            'stock'            => 123.4567,
             'slug'             => 'maxi-baxi-2000',
             'excerpt'          => 'Maxi Baxi 2000 is the THING you always have dreamt of',
             'description'      => 'Maxi Baxi 2000 makes your dreams come true. See: https://youtu.be/5RKM_VLEbOc',
@@ -66,6 +67,8 @@ class BaseProductAttributesTest extends TestCase
         $this->assertGreaterThanOrEqual(1, $product->id);
         $this->assertEquals('Maxi Baxi 2000', $product->name);
         $this->assertEquals('MXB-2000', $product->sku);
+        $this->assertEquals(123.4567, $product->stock);
+        $this->assertTrue($product->isOnStock());
         $this->assertEquals('maxi-baxi-2000', $product->slug);
         $this->assertEquals('Maxi Baxi 2000 is the THING you always have dreamt of', $product->excerpt);
         $this->assertEquals('Maxi Baxi 2000 makes your dreams come true. See: https://youtu.be/5RKM_VLEbOc',

--- a/tests/ProductStockTest.php
+++ b/tests/ProductStockTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Vanilo\Product\Tests;
+
+use Vanilo\Product\Models\Product;
+use Vanilo\Product\Models\ProductProxy;
+
+class ProductStockTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function field_value_can_be_specified()
+    {
+        $product = Product::create([
+            'name'  => 'Dell Latitude E7240 Laptop',
+            'sku'   => 'DLL-74237',
+            'stock' => 123.45
+        ]);
+
+        $this->assertEquals(123.45, $product->stock);
+    }
+
+    /**
+     * @test
+     */
+    public function field_value_returns_a_numeric_value()
+    {
+        $createdProduct = Product::create([
+            'name'  => 'Dell Latitude E7240 Laptop',
+            'sku'   => 'DLL-74237',
+            'stock' => 123.45
+        ]);
+
+        $product = Product::find($createdProduct->id);
+
+        $this->assertTrue(\is_numeric($product->stock));
+    }
+
+    /**
+     * @test
+     */
+    public function field_value_defaults_to_zero()
+    {
+        $product = Product::create([
+            'name' => 'Dell Latitude E7240 Laptop',
+            'sku'  => 'DLL-74237'
+        ]);
+
+        $this->assertEquals(0, $product->stock);
+    }
+
+    /**
+     * @test
+     */
+    public function isOnStock_returns_true_if_the_stock_is_greater_than_zero()
+    {
+        $product = Product::create([
+            'name'  => 'Dell Latitude E7240 Laptop',
+            'sku'   => 'DLL-74237',
+            'stock' => 123.45
+        ]);
+
+        $this->assertTrue($product->isOnStock());
+    }
+
+    /**
+     * @test
+     */
+    public function isOnStock_returns_false_if_the_stock_is_equal_to_zero()
+    {
+        $product = Product::create([
+            'name'  => 'Dell Latitude E7240 Laptop',
+            'sku'   => 'DLL-74237',
+            'stock' => 0
+        ]);
+
+        $this->assertFalse($product->isOnStock());
+    }
+
+    /**
+     * @test
+     */
+    public function isOnStock_returns_false_if_the_stock_is_less_than_zero()
+    {
+        $product = Product::create([
+            'name'  => 'Dell Latitude E7240 Laptop',
+            'sku'   => 'DLL-74237',
+            'stock' => -123.45
+        ]);
+
+        $this->assertFalse($product->isOnStock());
+    }
+}


### PR DESCRIPTION
This PR resolves #4. Implemented as mentioned in [this comment](https://github.com/vanilophp/product/issues/4#issuecomment-467399206).

### Some ideas:
Maybe a new `ProductState` stating stock status(_active but not on stock etc._) can be added. `$product->canBeBought()` that checks if `stock >= minimum_buy_amount` can be added in future, when some kind of minimum buying amount mechanism added.